### PR TITLE
feat: add conditional types to createKindeServerClient to select the type of options and client

### DIFF
--- a/supporting-files/README.md
+++ b/supporting-files/README.md
@@ -79,7 +79,6 @@ import {
   createKindeServerClient, 
   GrantType,
   type ACClientOptions,
-  type ACClient, 
 } from "@kinde-oss/kinde-typescript-sdk";
 
 const clientOptions: ACClientOptions = {
@@ -90,7 +89,7 @@ const clientOptions: ACClientOptions = {
   redirectURL: process.env.KINDE_REDIRECT_URL
 };
 
-const client = createKindeServerClient<ACClient, ACClientOptions>(
+const client = createKindeServerClient(
   GrantType.AUTHORIZATION_CODE, clientOptions
 );
 ```
@@ -101,7 +100,6 @@ import {
   createKindeServerClient, 
   GrantType,
   type PKCEClientOptions,
-  type ACClient, 
 } from "@kinde-oss/kinde-typescript-sdk";
 
 const clientOptions: PKCEClientOptions = {
@@ -111,7 +109,7 @@ const clientOptions: PKCEClientOptions = {
   redirectURL: process.env.KINDE_REDIRECT_URL
 };
 
-const client = createKindeServerClient<ACClient, PKCEClientOptions>(
+const client = createKindeServerClient(
   GrantType.PKCE, clientOptions
 );
 ```
@@ -122,7 +120,6 @@ import {
   createKindeServerClient, 
   GrantType,
   type CCClientOptions,
-  type CCClient, 
 } from "@kinde-oss/kinde-typescript-sdk";
 
 const clientOptions: CCClientOptions = {
@@ -132,7 +129,7 @@ const clientOptions: CCClientOptions = {
   logoutRedirectURL: process.env.KINDE_LOGOUT_REDIRECT_URL
 };
 
-const client = createKindeServerClient<CCClient, CCClientOptions>(
+const client = createKindeServerClient(
   GrantType.CLIENT_CREDENTIALS, clientOptions
 )
 ```
@@ -181,7 +178,6 @@ import {
   createKindeServerClient, 
   GrantType,
   type ACClientOptions,
-  type ACClient, 
 } from "@kinde-oss/kinde-typescript-sdk";
 
 const clientOptions: ACClientOptions = {
@@ -194,7 +190,7 @@ const clientOptions: ACClientOptions = {
   audience: 'api.example.com/v1'
 };
 
-const client = createKindeServerClient<ACClient, ACClientOptions>(
+const client = createKindeServerClient(
   GrantType.AUTHORIZATION_CODE, clientOptions
 );
 ```
@@ -230,7 +226,6 @@ import {
   createKindeServerClient, 
   GrantType,
   type ACClientOptions,
-  type ACClient, 
 } from "@kinde-oss/kinde-typescript-sdk";
 
 const clientOptions: ACClientOptions = {
@@ -243,7 +238,7 @@ const clientOptions: ACClientOptions = {
   framework: 'ExpressJS'
 };
 
-const client = createKindeServerClient<ACClient, ACClientOptions>(
+const client = createKindeServerClient(
   GrantType.AUTHORIZATION_CODE, clientOptions
 );
 ```

--- a/supporting-files/lib/sdk/clients/server/index.ts
+++ b/supporting-files/lib/sdk/clients/server/index.ts
@@ -11,12 +11,12 @@ import type {
   CCClientOptions,
 } from '../types';
 
-export const createKindeServerClient = <
-  C extends ACClient | CCClient,
-  O extends ACClientOptions | PKCEClientOptions | CCClientOptions
->(
-  grantType: GrantType,
-  options: O
+type Options<T> = T extends GrantType.PKCE ? PKCEClientOptions : T extends GrantType.AUTHORIZATION_CODE ? ACClientOptions : T extends GrantType.CLIENT_CREDENTIALS ? CCClientOptions : never;
+type Client<T> = T extends PKCEClientOptions ? ACClient : T extends ACClientOptions ? ACClient : T extends  CCClientOptions ? CCClient : never; 
+
+export const createKindeServerClient = <G extends GrantType>(
+  grantType: G,
+  options: Options<G>
 ) => {
   if (!isNodeEnvironment()) {
     throw new Error('this method must be invoked in a node.js environment');
@@ -25,15 +25,15 @@ export const createKindeServerClient = <
   switch (grantType) {
     case GrantType.AUTHORIZATION_CODE: {
       const clientOptions = options as ACClientOptions;
-      return createAuthCodeClient(clientOptions, false) as C;
+      return createAuthCodeClient(clientOptions, false) as Client<Options<G>>;
     }
     case GrantType.PKCE: {
       const clientOptions = options as PKCEClientOptions;
-      return createAuthCodeClient(clientOptions, true) as C;
+      return createAuthCodeClient(clientOptions, true) as Client<Options<G>>;
     }
     case GrantType.CLIENT_CREDENTIALS: {
       const clientOptions = options as CCClientOptions;
-      return createCCClient(clientOptions) as C;
+      return createCCClient(clientOptions) as Client<Options<G>>;
     }
     default: {
       throw new Error('Unrecognized grant type provided');

--- a/supporting-files/package.json
+++ b/supporting-files/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kinde-oss/kinde-typescript-sdk",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Kinde Typescript SDK",
   "main": "dist-cjs/index.js",
   "module": "dist/index.js",


### PR DESCRIPTION
# Explain your changes

The type definition of `createKindeServerClient` requires passing in the correct types into the function matching the grant type in order to type check the options and return the correct type client, e.g.

```typescript
const kindeClient = createKindeServerClient<ACClient, PKCEClientOptions>(GrantType.PKCE, {...});
```
and it doesn't prevent you from passing in mismatched types that will lead to problems at runtime, e.g.:

```typescript
const kindeClient = createKindeServerClient<ACClient, PKCEClientOptions>(GrantType.CLIENT_CREDENTIALS, {...});
```

However, we can figure out the types based on the grant type, so after these changes we can just do:

```typescript
const kindeClient = createKindeServerClient(GrantType.CLIENT_CREDENTIALS, {});
```

and it will automatically select the type of options and the type of the client returned.

# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
