### PR TITLE
fix: unicode breaks with atob

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 kinde-mgmt-api-specs.yaml
 additional/node_modules
 generated-sdk
+node_modules

--- a/supporting-files/lib/sdk/utilities/token-utils.ts
+++ b/supporting-files/lib/sdk/utilities/token-utils.ts
@@ -1,19 +1,7 @@
+import {jwtDecode} from 'jwt-decode';
 import type { TokenCollection, UserType, TokenType } from './types.js';
 import { type SessionManager } from '../session-managers/index.js';
 
-/**
- * Parses a provided JWT token to extract the payload segment of said
- * token.
- * @param token {string}
- * @returns {any}
- */
-const getTokenPayload = (token: string): any => {
-  try {
-    return JSON.parse(atob(token.split('.')[1]));
-  } catch (e) {
-    return null;
-  }
-};
 
 /**
  * Extracts the payload from the provided idToken and saves the extracted
@@ -26,7 +14,7 @@ const commitUserToMemoryFromToken = async (
   sessionManager: SessionManager,
   idToken: string
 ): Promise<void> => {
-  const idTokenPayload = getTokenPayload(idToken);
+  const idTokenPayload = jwtDecode(idToken);
   const user: UserType = {
     family_name: idTokenPayload.family_name,
     given_name: idTokenPayload.given_name,
@@ -49,7 +37,7 @@ export const commitTokenToMemory = async (
   token: string,
   type: TokenType
 ): Promise<void> => {
-  const tokenPayload = getTokenPayload(token);
+  const tokenPayload = jwtDecode(token);
   await sessionManager.setSessionItem(type, token);
   if (type === 'access_token') {
     await sessionManager.setSessionItem('access_token_payload', tokenPayload);
@@ -138,6 +126,6 @@ export const commitUserToMemory = async (
 export const isTokenExpired = (token: string | null): boolean => {
   if (!token) return true;
   const currentUnixTime = Math.floor(Date.now() / 1000);
-  const tokenPayload = getTokenPayload(token);
+  const tokenPayload = jwtDecode(token);
   return currentUnixTime >= tokenPayload.exp;
 };

--- a/supporting-files/package.json
+++ b/supporting-files/package.json
@@ -15,7 +15,7 @@
         "types": "./dist-cjs/types/index.d.ts",
         "default": "./dist-cjs/index.js"
       },
-      "import":{
+      "import": {
         "types": "./dist/types/index.d.ts",
         "default": "./dist/index.js"
       }
@@ -70,6 +70,7 @@
     "typescript": "^5.0.4"
   },
   "dependencies": {
+    "jwt-decode": "^4.0.0",
     "uncrypto": "^0.1.3"
   }
 }

--- a/supporting-files/pnpm-lock.yaml
+++ b/supporting-files/pnpm-lock.yaml
@@ -5,6 +5,9 @@ settings:
   excludeLinksFromLockfile: false
 
 dependencies:
+  jwt-decode:
+    specifier: ^4.0.0
+    version: 4.0.0
   uncrypto:
     specifier: ^0.1.3
     version: 0.1.3
@@ -3287,6 +3290,11 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
     dev: true
+
+  /jwt-decode@4.0.0:
+    resolution: {integrity: sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==}
+    engines: {node: '>=18'}
+    dev: false
 
   /kleur@3.0.3:
     resolution: {integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==}


### PR DESCRIPTION
# Explain your changes

Fix unicode decoding issue

For example `Balázs` was being converted to `BalÃ¡zs` due to the way atob handles unicode.

I've pulled in the `jwt-decode` library, but if we don't want that dependency we could explore something like https://developer.mozilla.org/en-US/docs/Glossary/Base64#the_unicode_problem

Also updated `.gitignore` as adding this library introduced a lot of changes in `node_modules`

# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
