### PR TITLE
fix: prevent trying to decode refresh token

### DIFF
--- a/supporting-files/lib/__tests__/sdk/oauth2-flows/ClientCredentials.spec.ts
+++ b/supporting-files/lib/__tests__/sdk/oauth2-flows/ClientCredentials.spec.ts
@@ -142,14 +142,14 @@ describe('ClientCredentials', () => {
     it('commits access token to memory, when a new one is fetched', async () => {
       const mockAccessToken = mocks.getMockAccessToken(clientConfig.authDomain);
       mocks.fetchClient.mockResolvedValue({
-        json: () => ({ access_token: mockAccessToken }),
+        json: () => ({ access_token: mockAccessToken.token }),
       });
 
       const client = new ClientCredentials(clientConfig);
       await client.getToken(sessionManager);
       expect(mocks.fetchClient).toHaveBeenCalledTimes(1);
       expect(await sessionManager.getSessionItem('access_token')).toBe(
-        mockAccessToken
+        mockAccessToken.token
       );
     });
   });

--- a/supporting-files/lib/sdk/utilities/token-utils.ts
+++ b/supporting-files/lib/sdk/utilities/token-utils.ts
@@ -37,11 +37,12 @@ export const commitTokenToMemory = async (
   token: string,
   type: TokenType
 ): Promise<void> => {
-  const tokenPayload = jwtDecode(token);
   await sessionManager.setSessionItem(type, token);
   if (type === 'access_token') {
+    const tokenPayload = jwtDecode(token);
     await sessionManager.setSessionItem('access_token_payload', tokenPayload);
   } else if (type === 'id_token') {
+    const tokenPayload = jwtDecode(token);
     await sessionManager.setSessionItem('id_token_payload', tokenPayload);
     await commitUserToMemoryFromToken(sessionManager, token);
   }

--- a/supporting-files/package.json
+++ b/supporting-files/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kinde-oss/kinde-typescript-sdk",
-  "version": "2.2.4",
+  "version": "2.3.0",
   "description": "Kinde Typescript SDK",
   "main": "dist-cjs/index.js",
   "module": "dist/index.js",


### PR DESCRIPTION
# Explain your changes

`jwtDecode` throws an error trying to decode the refresh token to payload, which isn't even used.

# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
